### PR TITLE
bug encoding multipart form post

### DIFF
--- a/quercus/src/main/java/com/caucho/quercus/env/Post.java
+++ b/quercus/src/main/java/com/caucho/quercus/env/Post.java
@@ -213,7 +213,7 @@ public class Post {
          if (bracketIndex >= 0 && bracketIndex < name.length() - 1) {
             // php/085c
          } else if (filename == null) {
-            StringValue value = env.createStringBuilder();
+            StringValue value = env.createBinaryBuilder();
 
             value.appendReadAll(is, Integer.MAX_VALUE);
 


### PR DESCRIPTION
Forms with enctype="multipart/form-data" not correctly interpret unicode when using init param
unicode: true
